### PR TITLE
fix: resolve Google Search Console JSON-LD parsing errors

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -117,9 +117,7 @@ const currentUrl = canonicalUrl || Astro.url.href;
 		</script>
 		
 		{structuredData && (
-			<script type="application/ld+json" is:inline>
-				{JSON.stringify(structuredData)}
-			</script>
+			<script type="application/ld+json" is:inline set:html={JSON.stringify(structuredData)}></script>
 		)}
 		<!-- Critical CSS for above-the-fold content -->
 		<style>

--- a/src/pages/extract-audio.astro
+++ b/src/pages/extract-audio.astro
@@ -288,61 +288,45 @@ import RecommendedTools from '../components/RecommendedTools.astro';
 				<!-- FAQ Section -->
 				<section>
 					<h3 class="text-2xl font-semibold text-gray-900 mb-8">Frequently Asked Questions</h3>
-					<div class="space-y-6" itemscope itemtype="https://schema.org/FAQPage">
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">Is the audio extractor free to use?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">Yes, completely free! Extract audio from as many videos as you want, with no limits or hidden charges.</p>
-							</div>
+					<div class="space-y-6">
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">Is the audio extractor free to use?</h4>
+							<p class="text-gray-600">Yes, completely free! Extract audio from as many videos as you want, with no limits or hidden charges.</p>
 						</article>
 						
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">What's the difference between MP3 and WAV?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">MP3 files are smaller and more compatible but slightly compressed. WAV files are larger but maintain perfect audio quality with no compression.</p>
-							</div>
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">What's the difference between MP3 and WAV?</h4>
+							<p class="text-gray-600">MP3 files are smaller and more compatible but slightly compressed. WAV files are larger but maintain perfect audio quality with no compression.</p>
 						</article>
 						
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">Are my video files kept private?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">Absolutely. All processing happens locally in your browser. Your videos never get uploaded to our servers or leave your device.</p>
-							</div>
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">Are my video files kept private?</h4>
+							<p class="text-gray-600">Absolutely. All processing happens locally in your browser. Your videos never get uploaded to our servers or leave your device.</p>
 						</article>
 						
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">Can I use this on mobile devices?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">Yes! The tool works on smartphones, tablets, and desktop computers. The interface automatically adapts to your screen size.</p>
-							</div>
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">Can I use this on mobile devices?</h4>
+							<p class="text-gray-600">Yes! The tool works on smartphones, tablets, and desktop computers. The interface automatically adapts to your screen size.</p>
 						</article>
 						
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">Will extracting audio reduce the quality?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">No quality loss occurs during extraction. We copy the original audio stream directly without re-encoding, preserving the exact same quality as the source video.</p>
-							</div>
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">Will extracting audio reduce the quality?</h4>
+							<p class="text-gray-600">No quality loss occurs during extraction. We copy the original audio stream directly without re-encoding, preserving the exact same quality as the source video.</p>
 						</article>
 						
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">What video formats are supported?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">We support all major video formats including MP4, WebM, AVI, MOV, MKV, FLV, and more. If your browser can play the video, we can extract its audio.</p>
-							</div>
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">What video formats are supported?</h4>
+							<p class="text-gray-600">We support all major video formats including MP4, WebM, AVI, MOV, MKV, FLV, and more. If your browser can play the video, we can extract its audio.</p>
 						</article>
 						
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">Is there a file size limit?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">The only limit is your device's available memory. Since processing happens locally, larger files just take a bit more time to extract.</p>
-							</div>
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">Is there a file size limit?</h4>
+							<p class="text-gray-600">The only limit is your device's available memory. Since processing happens locally, larger files just take a bit more time to extract.</p>
 						</article>
 						
-						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200" itemscope itemprop="mainEntity" itemtype="https://schema.org/Question">
-							<h4 class="font-semibold text-gray-900 mb-2" itemprop="name">Do I need to install any software?</h4>
-							<div itemscope itemprop="acceptedAnswer" itemtype="https://schema.org/Answer">
-								<p class="text-gray-600" itemprop="text">No installation required! The tool runs entirely in your web browser using modern web technologies. Just visit the page and start extracting.</p>
-							</div>
+						<article class="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
+							<h4 class="font-semibold text-gray-900 mb-2">Do I need to install any software?</h4>
+							<p class="text-gray-600">No installation required! The tool runs entirely in your web browser using modern web technologies. Just visit the page and start extracting.</p>
 						</article>
 					</div>
 				</section>
@@ -378,8 +362,9 @@ import RecommendedTools from '../components/RecommendedTools.astro';
 			}
 			
 			// Listen for custom events from AudioExtractor
-			document.addEventListener('videoExtractorViewChange', function(event: CustomEvent) {
-				const isLandingView = event.detail.currentView === 'landing';
+			document.addEventListener('videoExtractorViewChange', function(event) {
+				const customEvent = event as any;
+				const isLandingView = customEvent.detail.currentView === 'landing';
 				toggleHeader(isLandingView);
 			});
 		});


### PR DESCRIPTION
Fixed two critical GSC errors preventing rich results:

1. Missing '}' or object member name in /trim/ - Fixed JSON-LD script rendering in Layout.astro by using set:html attribute for proper structured data output instead of inline JSON.stringify

2. Duplicate FAQPage field in /extract-audio/ - Removed conflicting microdata schema markup from FAQ section, keeping only the complete JSON-LD FAQPage schema which is preferred by Google

Also fixed TypeScript error in event listener type annotation.

🤖 Generated with [Claude Code](https://claude.ai/code)